### PR TITLE
feat: 리프레시 토큰 재발급 및 로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// flyway
 	implementation 'org.flywaydb:flyway-core'
@@ -38,7 +40,6 @@ dependencies {
     runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/tr/autos/auth/controller/AuthController.java
+++ b/src/main/java/com/tr/autos/auth/controller/AuthController.java
@@ -10,12 +10,15 @@ import com.tr.autos.domain.user.repository.UserRepository;
 import com.tr.autos.jwt.JwtTokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -24,6 +27,7 @@ public class AuthController {
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final StringRedisTemplate stringRedisTemplate;
 
     @PostMapping("/signup")
     public ResponseEntity<SignupResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
@@ -37,8 +41,8 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(res);
     }
 
-    @PostMapping("/refresh")
-    public ResponseEntity<LoginResponseDto> refresh(@RequestHeader(value="Authorization", required=false) String bearer) {
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader(value="Authorization", required=false) String bearer) {
         if (bearer == null || !bearer.startsWith("Bearer ")) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
@@ -50,8 +54,53 @@ public class AuthController {
             }
             String email = claims.getSubject();
             var user = userRepository.findByEmail(email).orElseThrow();
+
+            String redisKey = "rt:" + user.getId();
+            stringRedisTemplate.delete(redisKey);
+
+            return ResponseEntity.noContent().build();
+        } catch (io.jsonwebtoken.JwtException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponseDto> refresh(@RequestHeader(value="Authorization", required=false) String bearer) {
+        if (bearer == null || !bearer.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+        var refreshToken = bearer.substring(7);
+        try {
+            var claims = jwtTokenProvider.parse(refreshToken).getBody();
+
+            // 1) 리프레시 토큰인지 확인
+            if (!"refresh".equals(claims.get("typ"))) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+
+            // 2) jti 추출
+            String tokenJti = String.valueOf(claims.get("jti"));
+            String email = claims.getSubject();
+
+            // 3) 사용자 조회
+            var user = userRepository.findByEmail(email).orElseThrow();
+
+            // 4) Redis의 jti와 일치하는지 확인
+            String redisKey = "rt:" + user.getId();
+            String storedJti = stringRedisTemplate.opsForValue().get(redisKey);
+            if (storedJti == null || !storedJti.equals(tokenJti)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+
+            // 5) 회전(rotate): 새 jti 발급 & Redis 갱신
+            String newJti = UUID.randomUUID().toString();
+            stringRedisTemplate.opsForValue()
+                    .set(redisKey, newJti, Duration.ofSeconds(jwtTokenProvider.refreshTtlSeconds()));
+
+            // 6) 새 토큰들 발급
             String newAccess = jwtTokenProvider.createAccessToken(user.getEmail(), user.getName());
-            String newRefresh = jwtTokenProvider.createRefreshToken(email); // (선택) 롤링
+            String newRefresh = jwtTokenProvider.createRefreshToken(email, newJti);
+
             return ResponseEntity.ok(new LoginResponseDto(email, user.getName(), newAccess, newRefresh));
         } catch (io.jsonwebtoken.JwtException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/src/main/java/com/tr/autos/auth/service/AuthService.java
+++ b/src/main/java/com/tr/autos/auth/service/AuthService.java
@@ -12,12 +12,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
+import java.time.Duration;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final StringRedisTemplate stringRedisTemplate;
 
     // 회원가입 로직
     @Transactional
@@ -54,9 +59,18 @@ public class AuthService {
             throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
         }
 
+        // 로그인 성공 후 토큰 발급 부분 교체
+        String jti = UUID.randomUUID().toString();
+
         // 토큰 발급(추후 코드 변경)
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getName());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail(), jti);
+
+        // Redis 에 jti 저장 (key: rt:{userId}, TTL: refresh 만료와 동일)
+        String redisKey = "rt:" + user.getId(); // userId 없으면 rt:{email}로 바꿔도 됨
+        stringRedisTemplate
+                .opsForValue()
+                .set(redisKey, jti, Duration.ofSeconds(jwtTokenProvider.refreshTtlSeconds()));
 
         // 반환
         return new LoginResponseDto(user.getEmail(), user.getName(), accessToken, refreshToken);

--- a/src/main/java/com/tr/autos/config/RedisConfig.java
+++ b/src/main/java/com/tr/autos/config/RedisConfig.java
@@ -1,0 +1,14 @@
+package com.tr.autos.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(LettuceConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/main/java/com/tr/autos/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tr/autos/jwt/JwtAuthenticationFilter.java
@@ -27,6 +27,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = header.substring(7);
             try {
                 var claims = jwtTokenProvider.parse(token).getBody();
+
+                Object typ = claims.get("typ");
+                if (!"access".equals(typ)) {
+                    // access 토큰이 아니면 인증 세팅하지 않고 다음 필터로 넘김
+                    fc.doFilter(req, res);
+                    return;
+                }
+
                 String email = claims.getSubject();
                 UsernamePasswordAuthenticationToken auth =
                         new UsernamePasswordAuthenticationToken(email, null, List.of());

--- a/src/main/java/com/tr/autos/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tr/autos/jwt/JwtTokenProvider.java
@@ -48,12 +48,13 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(String email) {
+    public String createRefreshToken(String email, String jti) {
         Instant now = Instant.now();
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
                 .setSubject(email)
                 .claim("typ", "refresh")        // ★ refresh 구분
+                .claim("jti", jti)
                 .setIssuer(issuer)
                 .setAudience(audience)
                 .setIssuedAt(Date.from(now))
@@ -77,5 +78,10 @@ public class JwtTokenProvider {
             throw new io.jsonwebtoken.JwtException("유효하지 않은 iss/aud");
         }
         return jws;
+    }
+
+    // Redis TTL 설정에 사용
+    public long refreshTtlSeconds() {
+        return refreshTtl;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+      username: default        # Redis 6+ ACL 기본 사용자명
+      password: autos_redis_pw # 설정한 requirepass 값
 
 jwt:
   secret: "b9IH2UxOIQgFl0ojWL63Gg9ztWt7T/gIeYV/hTSvFPw=" # Base64 문자열

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
     url: jdbc:mysql://localhost:3307/auto_trading?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     user: autos
     password: autos_pw
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: default        # Redis 6+ ACL 기본 사용자명
+      password: autos_redis_pw # 설정한 requirepass 값
 
 jwt:
   secret: 'b9IH2UxOIQgFl0ojWL63Gg9ztWt7T/gIeYV/hTSvFPw=' # 랜덤 문자열


### PR DESCRIPTION
## 🔥 이슈

#5 

## 📜 개요

리프레시 토큰 재발급, 로그아웃 구현

🔑 로그인
	•	로그인 성공 시:
	•	AccessToken + RefreshToken 발급
	•	RefreshToken에는 typ=refresh, jti=UUID claim 포함
	•	Redis에 rt:{userId}=jti 저장 (TTL = refresh 만료시간)

🔄 리프레시 토큰 재발급 (/auth/refresh)
	•	클라이언트가 Refresh 토큰을 보내면:
	•	typ=refresh인지 검증
	•	Redis에 저장된 jti와 토큰의 jti가 일치하는지 확인
	•	일치하면 새 Access + 새 Refresh 발급 (Refresh는 회전)
	•	Redis의 jti를 새 값으로 갱신

🚪 로그아웃 (/auth/logout)
	•	클라이언트가 Refresh 토큰을 보내면:
	•	typ=refresh 확인
	•	Redis에 저장된 rt:{userId} 키 삭제
	•	→ 해당 Refresh 토큰은 무효화됨, 재발급도 불가능

## 🤔 PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
