### PR TITLE
feat: 국내/해외주식 차트 불러오는 기능 구현

### DIFF
--- a/src/main/java/com/tr/autos/domain/quote/dto/StockChartDto.java
+++ b/src/main/java/com/tr/autos/domain/quote/dto/StockChartDto.java
@@ -1,0 +1,14 @@
+package com.tr.autos.domain.quote.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record StockChartDto(
+        Long symbolId,
+        String ticker,
+        String market,
+        LocalDate from,
+        LocalDate to,
+        String period,
+        List<StockChartPointDto> points
+) {}

--- a/src/main/java/com/tr/autos/domain/quote/dto/StockChartPointDto.java
+++ b/src/main/java/com/tr/autos/domain/quote/dto/StockChartPointDto.java
@@ -1,0 +1,13 @@
+package com.tr.autos.domain.quote.dto;
+
+import java.time.LocalDate;
+
+public record StockChartPointDto(
+        LocalDate date,
+        Long close,
+        Long open,
+        Long high,
+        Long low,
+        Long volume,
+        Long amount
+) {}

--- a/src/main/java/com/tr/autos/market/kis/KisMarketDataClient.java
+++ b/src/main/java/com/tr/autos/market/kis/KisMarketDataClient.java
@@ -1,0 +1,64 @@
+package com.tr.autos.market.kis;
+
+import com.tr.autos.market.kis.dto.KisDailyChartPriceResponse;
+import com.tr.autos.market.kis.service.KisTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisMarketDataClient {
+
+    private static final String DAILY_CHART_PATH = "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+    private final KisTokenService tokenService;
+
+    @Value("${kis.appkey}")
+    private String appKey;
+
+    @Value("${kis.appsecret}")
+    private String appSecret;
+
+    public KisDailyChartPriceResponse fetchDailyChart(String symbolCode,
+                                                       LocalDate from,
+                                                       LocalDate to,
+                                                       String periodDivCode,
+                                                       String marketDivCode,
+                                                       String orgAdjPriceFlag) {
+        String accessToken = tokenService.getAccessTokenOrRefresh();
+        try {
+            return restClient.get()
+                    .uri(builder -> builder
+                            .path(DAILY_CHART_PATH)
+                            .queryParam("FID_COND_MRKT_DIV_CODE", marketDivCode)
+                            .queryParam("FID_INPUT_ISCD", symbolCode)
+                            .queryParam("FID_INPUT_DATE_1", DATE_FORMATTER.format(from))
+                            .queryParam("FID_INPUT_DATE_2", DATE_FORMATTER.format(to))
+                            .queryParam("FID_PERIOD_DIV_CODE", periodDivCode)
+                            .queryParam("FID_ORG_ADJ_PRC", orgAdjPriceFlag)
+                            .build())
+                    .header(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
+                    .header("authorization", "Bearer " + accessToken)
+                    .header("appkey", appKey)
+                    .header("appsecret", appSecret)
+                    .header("tr_id", "FHKST03010100")
+                    .header("custtype", "P")
+                    .retrieve()
+                    .body(KisDailyChartPriceResponse.class);
+        } catch (RestClientException e) {
+            log.error("[KIS] 일별 차트 조회 실패 symbol={} from={} to={} : {}", symbolCode, from, to, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/tr/autos/market/kis/dto/KisDailyChartPriceResponse.java
+++ b/src/main/java/com/tr/autos/market/kis/dto/KisDailyChartPriceResponse.java
@@ -1,0 +1,38 @@
+package com.tr.autos.market.kis.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KisDailyChartPriceResponse(
+        @JsonProperty("rt_cd") String rtCd,
+        @JsonProperty("msg_cd") String msgCd,
+        @JsonProperty("msg1") String msg,
+        @JsonProperty("output1") Output1 output1,
+        @JsonProperty("output2") List<Output2> output2
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output1(
+            @JsonProperty("hts_kor_isnm") String koreanName,
+            @JsonProperty("stck_shrn_iscd") String shortCode,
+            @JsonProperty("stck_prdy_clpr") String prevClose,
+            @JsonProperty("stck_prpr") String currentPrice
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output2(
+            @JsonProperty("stck_bsop_date") String businessDate,
+            @JsonProperty("stck_clpr") String closePrice,
+            @JsonProperty("stck_oprc") String openPrice,
+            @JsonProperty("stck_hgpr") String highPrice,
+            @JsonProperty("stck_lwpr") String lowPrice,
+            @JsonProperty("acml_vol") String accumulatedVolume,
+            @JsonProperty("acml_tr_pbmn") String accumulatedTransactionAmount,
+            @JsonProperty("prdy_vrss") String prevDiff,
+            @JsonProperty("prdy_vrss_sign") String prevDiffSign,
+            @JsonProperty("mod_yn") String modified
+    ) {}
+}

--- a/src/main/java/com/tr/autos/quote/controller/StockDetailController.java
+++ b/src/main/java/com/tr/autos/quote/controller/StockDetailController.java
@@ -1,21 +1,39 @@
 package com.tr.autos.quote.controller;
 
+import com.tr.autos.domain.quote.dto.StockChartDto;
 import com.tr.autos.domain.quote.dto.StockDetailDto;
+import com.tr.autos.quote.service.StockChartService;
 import com.tr.autos.quote.service.StockDetailReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/stocks")
 @RequiredArgsConstructor
 public class StockDetailController {
     private final StockDetailReadService readService;
+    private final StockChartService chartService;
 
     @GetMapping("/id/{symbolId}/detail")
     public StockDetailDto detailById(@PathVariable Long symbolId) {
         return readService.readFromCache(symbolId);
+    }
+
+    @GetMapping("/id/{symbolId}/chart")
+    public StockChartDto chartById(@PathVariable Long symbolId,
+                                   @RequestParam(value = "from", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+                                   @RequestParam(value = "to", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+                                   @RequestParam(value = "period", defaultValue = "D") String period,
+                                   @RequestParam(value = "adjusted", defaultValue = "true") boolean adjusted) {
+        return chartService.getDailyChart(symbolId, from, to, period, adjusted);
     }
 }

--- a/src/main/java/com/tr/autos/quote/service/StockChartService.java
+++ b/src/main/java/com/tr/autos/quote/service/StockChartService.java
@@ -1,0 +1,184 @@
+package com.tr.autos.quote.service;
+
+import com.tr.autos.domain.quote.dto.StockChartDto;
+import com.tr.autos.domain.quote.dto.StockChartPointDto;
+import com.tr.autos.domain.symbol.Symbol;
+import com.tr.autos.domain.symbol.repository.SymbolRepository;
+import com.tr.autos.market.kis.KisMarketDataClient;
+import com.tr.autos.market.kis.dto.KisDailyChartPriceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockChartService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter RESPONSE_DATE_FORMAT = DateTimeFormatter.BASIC_ISO_DATE; // yyyyMMdd
+    private static final int MAX_RECORDS_PER_REQUEST = 100;
+
+    private final SymbolRepository symbolRepository;
+    private final KisMarketDataClient marketDataClient;
+
+    @Transactional(readOnly = true)
+    public StockChartDto getDailyChart(Long symbolId,
+                                       LocalDate requestedFrom,
+                                       LocalDate requestedTo,
+                                       String periodCode,
+                                       boolean useAdjustedPrice) {
+        Symbol symbol = symbolRepository.findById(symbolId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "symbol not found"));
+
+        if (!"KRX".equalsIgnoreCase(symbol.getMarket())) {
+            throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "국내주식(KRX) 차트만 지원합니다.");
+        }
+
+        LocalDate to = requestedTo != null ? requestedTo : LocalDate.now(KST);
+        LocalDate from = requestedFrom != null ? requestedFrom : to.minusMonths(3);
+
+        if (from.isAfter(to)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "from 날짜가 to 날짜보다 늦을 수 없습니다.");
+        }
+
+        String period = (periodCode == null || periodCode.isBlank()) ? "D" : periodCode.toUpperCase();
+        String marketDivCode = "J"; // KRX 전체
+        String adjFlag = useAdjustedPrice ? "0" : "1"; // 0:수정주가, 1:원주가
+
+        List<KisDailyChartPriceResponse.Output2> rawOutputs;
+        try {
+            rawOutputs = fetchChartOutputs(symbol.getTicker(), from, to, period, marketDivCode, adjFlag);
+        } catch (RestClientException e) {
+            log.warn("[KIS] 차트 API 호출 실패 symbol={} : {}", symbol.getTicker(), e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "차트 데이터를 가져오는데 실패했습니다.");
+        }
+
+        List<StockChartPointDto> points = rawOutputs.stream()
+                .map(this::toPoint)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        StockChartPointDto::date,
+                        point -> point,
+                        (existing, candidate) -> candidate,
+                        TreeMap::new
+                ))
+                .values().stream()
+                .sorted(Comparator.comparing(StockChartPointDto::date))
+                .toList();
+
+        return new StockChartDto(
+                symbol.getId(),
+                symbol.getTicker(),
+                symbol.getMarket(),
+                from,
+                to,
+                period,
+                points
+        );
+    }
+
+    private List<KisDailyChartPriceResponse.Output2> fetchChartOutputs(String ticker,
+                                                                       LocalDate from,
+                                                                       LocalDate to,
+                                                                       String period,
+                                                                       String marketDivCode,
+                                                                       String adjFlag) {
+        List<KisDailyChartPriceResponse.Output2> aggregated = new ArrayList<>();
+
+        boolean requiresChunking = "D".equalsIgnoreCase(period)
+                && ChronoUnit.DAYS.between(from, to) >= MAX_RECORDS_PER_REQUEST;
+
+        if (!requiresChunking) {
+            KisDailyChartPriceResponse response = marketDataClient.fetchDailyChart(
+                    ticker, from, to, period, marketDivCode, adjFlag
+            );
+            validateResponse(response);
+            if (response.output2() != null) {
+                aggregated.addAll(response.output2());
+            }
+            return aggregated;
+        }
+
+        LocalDate segmentEnd = to;
+        while (!segmentEnd.isBefore(from)) {
+            LocalDate segmentStart = segmentEnd.minusDays(MAX_RECORDS_PER_REQUEST - 1L);
+            if (segmentStart.isBefore(from)) {
+                segmentStart = from;
+            }
+
+            KisDailyChartPriceResponse response = marketDataClient.fetchDailyChart(
+                    ticker, segmentStart, segmentEnd, period, marketDivCode, adjFlag
+            );
+            validateResponse(response);
+            if (response.output2() != null) {
+                aggregated.addAll(response.output2());
+            }
+
+            segmentEnd = segmentStart.minusDays(1);
+        }
+
+        return aggregated;
+    }
+
+    private void validateResponse(KisDailyChartPriceResponse response) {
+        if (response == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "KIS 차트 응답이 비어 있습니다.");
+        }
+
+        if (!"0".equals(response.rtCd())) {
+            String message = response.msg() != null ? response.msg() : "KIS API 오류";
+            log.warn("[KIS] 차트 조회 실패 rt_cd={} msg_cd={} msg={}", response.rtCd(), response.msgCd(), message);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message);
+        }
+    }
+
+    private StockChartPointDto toPoint(KisDailyChartPriceResponse.Output2 output) {
+        LocalDate date = parseDate(output.businessDate());
+        Long close = parseLong(output.closePrice());
+        if (date == null || close == null) {
+            return null;
+        }
+        Long open = parseLong(output.openPrice());
+        Long high = parseLong(output.highPrice());
+        Long low = parseLong(output.lowPrice());
+        Long volume = parseLong(output.accumulatedVolume());
+        Long amount = parseLong(output.accumulatedTransactionAmount());
+
+        return new StockChartPointDto(date, close, open, high, low, volume, amount);
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return LocalDate.parse(value.trim(), RESPONSE_DATE_FORMAT);
+    }
+
+    private Long parseLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            log.debug("[KIS] 숫자 파싱 실패 value={}", value);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 이슈

#15

## 📜 개요

- 개별 종목의 차트를 불러와서 일/월/년 단위로 볼 수 있도록 구현한다.
- 파라미터 값을 수정하여 1개월/3개월/6개월/1년 단위로 차트를 불러온다.
<img width="1072" height="464" alt="image" src="https://github.com/user-attachments/assets/5b12a6c5-939c-4dd0-a5a5-c2398913d19f" />
(애플 주가 예시) - 추후 원 -> 달러 수정

## 🤔 PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).



